### PR TITLE
TTO-17 - draw text lines from the top of the page

### DIFF
--- a/lib/Process/Volume/PDF.pm
+++ b/lib/Process/Volume/PDF.pm
@@ -397,7 +397,7 @@ sub generate_pdf {
                     if ( $$data{uses_coordinates} ) {
                         $self->insert_text_as_coordinates($page, $data, $original_w, $original_h, $xpos, $ypos, $ratio );
                     } else {
-                        $self->insert_text_as_lines($page, $data, $y1);
+                        $self->insert_text_as_lines($page, $data, $y2);
                     }
                 };
 


### PR DESCRIPTION
`Process::Volume::PDF::insert_text_as_lines` was being passed the "bottom" of the page, which meant text was being drawn too close to the edge of the page, making the text invisible to certain PDF readers. (PDF page coordinates have `0` at the bottom of the page.)

The fix is to send the "top" of the page to `insert_text_as_lines`.

To test: use `coo.31924059412902`, e.g. downloading the volume from https://dev-3.babel.hathitrust.org/cgi/pt?id=coo.31924059412902. You should be able to find pages with `jacobi` --- there are no coordinates, so the text is painted as "invisible".
