### PR TITLE
DEV-663: Add geoip DB so pageturner will work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,9 @@ RUN cpanm --notest \
   IP::Geolocation::MMDB \
   UUID
 
+WORKDIR /htapps/babel/geoip
+ADD --chmod=644 https://github.com/maxmind/MaxMind-DB/blob/main/test-data/GeoIP2-Country-Test.mmdb?raw=true GeoIP2-Country.mmdb
+
 RUN ln -s /tmp /ram
 
 RUN mkdir -p /l/local/bin


### PR DESCRIPTION
I may end up moving this into https://github.com/hathitrust/babel-local-dev, so leaving this as draft for now.