### PR TITLE
TTO-50 - use transformers configuration for all Process::Image use

### DIFF
--- a/apps/download.psgi
+++ b/apps/download.psgi
@@ -10,13 +10,15 @@ use Plack::Util;
 use Utils;
 
 use Utils::Settings;
-my $settings = Utils::Settings::load('imgsrv', 'download');
+our $settings = Utils::Settings::load('imgsrv', 'download');
 
 my $app = sub {
     my $env = shift;
     my $C = $$env{'psgix.context'};
     my $mdpItem = $C->get_object('MdpItem');
     my $item_type = lc $mdpItem->GetItemType();
+    $$env{'psgix.image.transformers'} = $$settings{transformers};
+    $$env{'psgix.image.verbose'} = $$settings{verbose};
     unless ( $$env{PATH_INFO} ) { $$env{PATH_INFO} = '/pdf'; }
     Plack::Recursive::ForwardRequest->throw("/$item_type$$env{PATH_INFO}");
 };

--- a/bin/pdf
+++ b/bin/pdf
@@ -35,6 +35,7 @@ my @config = (
     "bundle_format=s",
     "target_ppi=s",
     "quality=s",
+    "include_images=s",
     "super",
     "force",
 );

--- a/lib/Package/EPUB/Volume.pm
+++ b/lib/Package/EPUB/Volume.pm
@@ -106,7 +106,7 @@ sub generate {
 
     $updater->update(0);
 
-    $self->build_content();
+    $self->build_content($env);
 
     $self->build_toc($nav);
 
@@ -189,6 +189,7 @@ sub build_navigation {
 
 sub build_content {
     my $self = shift;
+    my ( $env ) = @_;
 
     my $updater = $self->updater;
     my $mdpItem = $self->mdpItem;
@@ -205,7 +206,7 @@ sub build_content {
 
         $has_content += 1;
 
-        my $xslt_params = $self->process_page_image($seq);
+        my $xslt_params = $self->process_page_image($env, $seq);
         $self->process_page_text($seq, $xslt_params);
     }
 }
@@ -411,7 +412,7 @@ sub get_page_basename {
 
 sub process_page_image {
     my $self = shift;
-    my ( $seq ) = @_;
+    my ( $env, $seq ) = @_;
     my $params = {};
     return $params unless ( $self->include_images );
 
@@ -423,6 +424,7 @@ sub process_page_image {
     $processor->output( filename => $self->pathname("images/$basename.jpg") );
     $processor->format("image/jpeg");
     $processor->size("100");
+    $processor->transformers( $$env{'psgix.image.transformers'} ) if ( defined $$env{'psgix.image.transformers'} );
     $processor->process();
     ( $$params{width}, $$params{height} ) = imgsize($processor->output->{filename});
     $$params{image_src} = "'../images/$basename.jpg'";

--- a/lib/Package/Image/Volume.pm
+++ b/lib/Package/Image/Volume.pm
@@ -86,7 +86,7 @@ sub generate {
 
     $updater->update(0);
 
-    $self->build_content();
+    $self->build_content($env);
 
     die "IMAGE BUNDLE CANCELLED" if ( $updater->is_cancelled );
 
@@ -96,6 +96,7 @@ sub generate {
 
 sub build_content {
     my $self = shift;
+    my ( $env ) = @_;
 
     my $updater = $self->updater;
     my $mdpItem = $self->mdpItem;
@@ -117,7 +118,7 @@ sub build_content {
         $i += 1;
         $updater->update($i);
 
-        $self->process_page_image($seq);
+        $self->process_page_image($env, $seq);
     }
 
     unlink $self->working_dir . "/process.log";
@@ -137,7 +138,7 @@ sub get_page_basename {
 
 sub process_page_image {
     my $self = shift;
-    my ( $seq) = @_;
+    my ( $env, $seq) = @_;
 
     my $extract_filename = $self->mdpItem->GetFilePathMaybeExtract($seq, 'imagefile');
 
@@ -166,6 +167,7 @@ sub process_page_image {
     # $processor->max_dim($max_dimension) if ( $max_dimension );
     $processor->quality($self->quality);
     $processor->blank($blank) if ( $blank );
+    $processor->transformers( $$env{'psgix.image.transformers'} ) if ( defined $$env{'psgix.image.transformers'} );
 
     $processor->process();
 }

--- a/lib/Process/Volume/EPUB.pm
+++ b/lib/Process/Volume/EPUB.pm
@@ -22,6 +22,7 @@ use Plack::Util::Accessor qw(
     target_ppi 
     watermark
     watermark_filename 
+    include_images
     output_fh
     working_dir
     updater
@@ -103,6 +104,7 @@ sub process {
         handle => $self->handle,
         working_dir => $working_dir,
         pages => $self->pages,
+        include_images => ($self->include_images || 0),
         watermark => $self->watermark,
     ));
 

--- a/lib/Process/Volume/EPUB.pm
+++ b/lib/Process/Volume/EPUB.pm
@@ -123,7 +123,6 @@ sub process {
 
     # and then rename the output_file
     if ( $do_rename ) {
-        print STDERR "AHOY WUT? " . $self->output_filename . "\n";
         rename($self->output_filename . ".download", $self->output_filename) || die $!;
     }
 

--- a/lib/Process/Volume/PDF.pm
+++ b/lib/Process/Volume/PDF.pm
@@ -301,6 +301,7 @@ sub generate_pdf {
             $processor->quality($self->quality);
 
             $processor->max_dim($self->max_dim) if ( $self->max_dim );
+            $processor->transformers( $$env{'psgix.image.transformers'} ) if ( defined $$env{'psgix.image.transformers'} );
             $processor->logfile("$input_dir/process.log");
 
             my $efi_hr = $processor->process();

--- a/lib/Process/Volume/PDF/EBM.pm
+++ b/lib/Process/Volume/PDF/EBM.pm
@@ -96,6 +96,7 @@ sub generate_pdf {
             $processor->size("res:1");
             $processor->quality('grey');
             $processor->max_dim($self->max_dim) if ( $self->max_dim );
+            $processor->transformers( $$env{'psgix.image.transformers'} ) if ( defined $$env{'psgix.image.transformers'} );
             $processor->logfile("$input_dir/process.log");
 
             my $efi_hr = $processor->process();

--- a/lib/SRV/Cover.pm
+++ b/lib/SRV/Cover.pm
@@ -99,6 +99,7 @@ sub run {
     $processor->restricted($restricted); # until covers really go live
     $processor->max_dim($max_dimension) if ( $max_dimension );
     $processor->quality($self->quality);
+    $processor->transformers( $$env{'psgix.image.transformers'} ) if ( defined $$env{'psgix.image.transformers'} );
     # $processor->blank($blank) if ( $blank );
 
     my $output = $processor->process();

--- a/lib/SRV/Volume/EPUB.pm
+++ b/lib/SRV/Volume/EPUB.pm
@@ -32,6 +32,7 @@ use Plack::Util::Accessor qw(
     watermark 
     max_dim
     is_partial 
+    include_images 
     attachment_filename
     id
 );
@@ -73,6 +74,7 @@ sub new {
     $self->watermark(1) unless ( defined $self->watermark );
     $self->target_ppi(0) unless ( defined $self->target_ppi );
     $self->searchable(1) unless ( defined $self->searchable );
+    $self->include_images(0) unless ( defined $self->include_images );
 
     $self->is_partial(0);
 
@@ -294,6 +296,7 @@ sub run {
         rotation => $self->rotation,
         target_ppi => $self->target_ppi,
         watermark => $self->watermark,
+        include_images => $self->include_images,
         # max_dim => $self->max_dim,
         pages => $self->pages,
         updater => $updater,
@@ -317,6 +320,8 @@ sub _fill_params {
         progress_filepath => undef,
         download_url => undef,
     );
+    # include_images is only possible using magic XYZZY option
+    $params{include_images} = undef if ( $ENV{XYZZY} );
 
     SRV::Utils::parse_env(\%params, [qw(file rotation format output_filename)], $req, $args);
 

--- a/lib/SRV/Volume/Image/Bundle.pm
+++ b/lib/SRV/Volume/Image/Bundle.pm
@@ -94,9 +94,10 @@ sub _authorize {
     unless ( $self->restricted ) {
         # technically the user has access but we need to 
         # limit resources for bundling to users in a current session
+        # unless you're using XYZZY=1 on the command line
         my $C = $$env{'psgix.context'};
         my $ses = $C->get_object('Session');
-        if ( $$ses{is_new} ) { $self->restricted(1); }
+        if ( $$ses{is_new} && ! $ENV{XYZZY} ) { $self->restricted(1); }
         elsif ( $self->format eq 'image/tiff' && $self->total_pages > 10 ) {
             $self->restricted(1);
         }


### PR DESCRIPTION
Currently in production (until we deploy Debian bookwork?) JPEG2000s are transformed using Kakaduo. This is configured in the `imsrv.json` settings file as 

```
  "transformers": {
      "image/jp2": "kakadu"
  }
```

`SRV::Image` (the app that answers `/imgsrv/image` had previously been updated to support configuring the `image/jp2` transformer by way of the settings. This PR updates the other scenarios where `Process::Image` is invoked.

To test you'll need kakadu installed, and `$SDRROOT/etc/settings/imgsrv/imgsrv.json` to have that transformers snippet.

`SRV::Cover` - given an htid, access the URL `/imgsrv/cover?id=$htid`

Image Bundling (for downloads): 

```
SDRVIEW=full XYZZY=1 ./bin/image_bundle --id $htid --format image/jpeg --target_ppi 300 --bundle_format zip --output_filename /tmp/bundle.zip
```

...and then run it again; bundling is a complicated dance usually of forked processes, and the second run will rename the temporary ZIP that's in `cache/download` to your actual filename.

EPUBs with images:

```
SDRVIEW=full XYZZY=1 ./bin/epub --id $htid--include_images=1 --output_filename /tmp/$htid.epub
```

*What's with the `XYZZY`?* The download bundling returns a 403 if the user is using a brand new session --- e.g. not initiating the download from the reader. Running from the terminal looks like a new session. Huzzah.