### PR TITLE
DEV-1076: metrics for imgsrv

### DIFF
--- a/apps/imgsrv.psgi
+++ b/apps/imgsrv.psgi
@@ -102,7 +102,11 @@ builder {
                      ;
     }
 
-    enable "+SRV::Prolog", app_name => 'imgsrv';
+    # The "+" indicates this is a complete class name, and we shouldn't prefix
+    # it with 'Plack::Middleware::"
+    enable "+SRV::Metrics";
+    enable match_if path('!',qr,/metrics,), "+SRV::Prolog", app_name => 'imgsrv';
+    #enable "+SRV::Prolog", app_name => 'imgsrv';
     enable "Recursive";
 
     mount "/" => $app;
@@ -150,6 +154,10 @@ builder {
         mount "/cover" => $covers_app;
         mount "/html" => SRV::Article::HTML->new;
         # mount "/file" => ...;
-    }
+    };
+    mount "/metrics" => sub {
+      my $env = shift;
+      return $env->{'psgix.metrics'}->render;
+    };
 
 };

--- a/apps/imgsrv.psgi
+++ b/apps/imgsrv.psgi
@@ -104,7 +104,7 @@ builder {
 
     # The "+" indicates this is a complete class name, and we shouldn't prefix
     # it with 'Plack::Middleware::"
-    enable "+SRV::Metrics";
+    enable_if { ! $ENV{HEALTHCHECK} } "+SRV::Metrics";
     enable match_if path('!',qr,/metrics,), "+SRV::Prolog", app_name => 'imgsrv';
     #enable "+SRV::Prolog", app_name => 'imgsrv';
     enable "Recursive";

--- a/bin/catprocio
+++ b/bin/catprocio
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+pid=$1
+
+# ensure given a numeric process ID
+[[ "$pid" =~ ^[0-9]+$ ]] || exit 1
+
+# ensure running via sudo
+[[ "$(readlink /proc/$PPID/exe)" == "/usr/bin/sudo" ]] || exit 2
+
+# the grandparent of this process (i.e. the parent of sudo) must be the same as
+# the parent of the process we're checking
+
+parent=$(cut -f 4 -d ' ' "/proc/$pid/stat")
+this_grandpid=$(cut -f 4 -d ' ' "/proc/$PPID/stat")
+
+[[ "$parent" == "$this_grandpid" ]] || exit 3
+
+cat "/proc/$pid/io"

--- a/lib/Process/Image.pm
+++ b/lib/Process/Image.pm
@@ -18,6 +18,7 @@ use JSON::XS;
 use POSIX qw(ceil floor);
 
 use Plack::Util::Accessor qw(
+    metrics
     mdpItem
     region
     size
@@ -214,6 +215,9 @@ sub _run {
 
         unlink $self->tmpfilename;
         $self->tmpfilename($jp2_tmpfilename);
+    }
+    if(my $metrics = $self->metrics) {
+      $metrics->observe("imgsrv_process_image_seconds",time()-$t0, { mimetype => $self->output->{mimetype} });
     }
 
     ### print STDERR "DELTA: ", ( time() - $t0 ), "\n";

--- a/lib/SRV/Metrics.pm
+++ b/lib/SRV/Metrics.pm
@@ -1,0 +1,89 @@
+package SRV::Metrics;
+
+use strict;
+use parent qw(Plack::Middleware);
+
+use Prometheus::Tiny::Shared;
+use Plack::Request;
+use Time::HiRes qw(time);
+
+sub new {
+  my $class = shift;
+  my $self = $class->SUPER::new(@_);
+
+  warn("Setting up metrics (in pid $$)");
+  $self->{prom} = Prometheus::Tiny::Shared->new;
+  $self->setup_metrics;
+
+  return $self;
+}
+
+sub setup_metrics {
+  my $self = shift;
+  my $prom = $self->{prom};
+
+  $prom->declare(
+    "imgsrv_requests",
+    type => "counter",
+    help => "number of handled requests",
+  );
+
+  $prom->declare(
+    "imgsrv_request_seconds",
+    type => "histogram",
+    help => "Summary request processing time",
+  );
+}
+
+# Mostly cribbed from SRV::Prolog and the Plack::Middleware info
+sub call {
+  my ($self, $env) = @_;
+
+  # expose for other parts of the app to set their own metrics
+  $env->{'psgix.metrics'} = $self;
+
+  my $start = time();
+
+  my $res = $self->app->($env);
+
+  # track metrics from result
+  # track failures?
+
+  $self->response_cb($res, sub { $self->finalize($env, $start, $_[0]) });
+
+}
+
+sub render {
+  my $self = shift;
+
+  return [ 200, [ 'Content-Type' => 'text/plain' ], [ $self->{prom}->format ] ];
+}
+
+sub finalize {
+  my ($self, $env, $start, $res) = @_;
+
+  my $req = Plack::Request->new($env);
+
+  my $response_code = $res->[0];
+  my $labels = {
+    response_code => $response_code
+  };
+
+  $labels->{path_info} = $req->path_info unless $response_code == '404';
+
+  $self->{prom}->histogram_observe("imgsrv_request_seconds", time() - $start, $labels);
+  $self->{prom}->inc( "imgsrv_requests", $labels );
+}
+
+# counter: cache hits
+# counter: cache misses
+# counter: bytes read from disk; label: location (cache vs. uncached)
+
+# histogram: seconds per request
+# labels: endpoint
+# labels: stage
+
+# process collector
+# prefix: imgsrv
+
+1;


### PR DESCRIPTION
## Background

This pull request is about trying to collect metrics on how long various operations take as part of delivering content to end users, especially operations that involve filesystem use.

See also: https://github.com/mlibrary/nebula/pull/679, https://github.com/hathitrust/mdp-lib/pull/35

## Overview

This provides:

* setup for prometheus metrics
* recording metrics & cache hit/miss stats for imgsrv operations
* a metrics exporter endpoint in imgsrv (see e.g. https://beta-1.babel.hathitrust.org/cgi/imgsrv/metrics)
* the `catprocio` script is also in https://github.com/mlibrary/nebula/pull/679 (included here for development/testing purposes; feel better to deploy a script we will run with sudo using puppet to /usr/local/bin though than as part of the application which is why it's over there too)

## Reviewing

I'm not wild that we push the whole metrics thing down to `Utils::Extract` and other parts of mdp-lib; an alternative would be to have those methods return some metrics to the caller, but that doesn't seem quite right either and would require more thought.

@mwarin I included you as a reviewer since you have been working on metrics in ingest. More of the prometheus setup will be in the corresponding imgsrv pull request
@moseshll I included you as a reviewer since you have some experience with mdp-lib, and might be able to weigh in on the shenanigans in Utils::MonitorRun.

See also: https://github.com/hathitrust/mdp-lib/pull/35, https://github.com/mlibrary/nebula/pull/679

We will also need to update the `mdp-lib` submodule here after https://github.com/hathitrust/mdp-lib/pull/35 is merged (this will fail without the updated mdp-lib), which is why this PR is still in draft