### PR TITLE
Experiment with singleton Metrics object provided by mdp-lib

### DIFF
--- a/lib/Process/Image.pm
+++ b/lib/Process/Image.pm
@@ -42,6 +42,8 @@ use Process::Globals;
 
 use Time::HiRes qw(time);
 
+use Metrics;
+
 our $MIN_IMAGE_SIZE = 5;
 
 our $mimetypes = MIME::Types->new;
@@ -216,9 +218,7 @@ sub _run {
         unlink $self->tmpfilename;
         $self->tmpfilename($jp2_tmpfilename);
     }
-    if(my $metrics = $self->metrics) {
-      $metrics->observe("imgsrv_process_image_seconds",time()-$t0, { mimetype => $self->output->{mimetype} });
-    }
+    Metrics->new->observe("imgsrv_process_image_seconds",time()-$t0, { mimetype => $self->output->{mimetype} });
 
     ### print STDERR "DELTA: ", ( time() - $t0 ), "\n";
 

--- a/lib/SRV/Metrics.pm
+++ b/lib/SRV/Metrics.pm
@@ -3,7 +3,7 @@ package SRV::Metrics;
 use strict;
 use parent qw(Plack::Middleware);
 
-use Prometheus::Tiny::Shared;
+use Metrics;
 use Plack::Request;
 use Time::HiRes qw(time);
 
@@ -12,7 +12,7 @@ sub new {
   my $self = $class->SUPER::new(@_);
 
   warn("Setting up metrics (in pid $$)");
-  $self->{prom} = Prometheus::Tiny::Shared->new;
+  $self->{prom} = Metrics->new;
   $self->setup_metrics;
 
   return $self;
@@ -51,6 +51,18 @@ sub setup_metrics {
     type => "histogram",
     help => "Summary time spent in Process::Image::run"
   );
+
+  $prom->declare(
+    "utils_extract_run_seconds",
+    type => "histogram",
+    help => "Help string for utils_extract_run_seconds"
+  );
+
+  $prom->declare(
+    "utils_extract_extracted_size_bytes",
+    type => "counter",
+    help => "Help string for utils_extract_extracted_size_bytes"
+  );
 }
 
 # Mostly cribbed from SRV::Prolog and the Plack::Middleware info
@@ -71,9 +83,10 @@ sub call {
 
 }
 
+# These wrappers are likely unnecessary given that the mdp-lib Metrics object is a singleton. 
 sub observe {
   my $self = shift;
-  $self->{prom}->histogram_observe(@_);
+  $self->{prom}->observe(@_);
 }
 
 sub add {

--- a/lib/SRV/Prolog.pm
+++ b/lib/SRV/Prolog.pm
@@ -44,6 +44,7 @@ use Identifier;
 use Scalar::Util;
 use Try::Tiny;
 
+use Metrics;
 use Utils;
 
 # Return codes from ValidityChecks()
@@ -101,9 +102,6 @@ sub setup_context {
     my $C = new Context;
     my $req = Plack::Request->new($env);
 
-    my $metrics = $env->{'psgix.metrics'};
-    $C->set_object('Metrics', $metrics) if $metrics;
-
     my $app = new App($C, $self->app_name);
     $C->set_object('App', $app);
 
@@ -160,7 +158,7 @@ sub setup_context {
         MdpItem->GetMdpItem($C, $id, $itemFileSystemLocation);
     $C->set_object('MdpItem', $mdpItem);
 
-    $metrics->observe("imgsrv_prolog_seconds", time() - $start) if $metrics;
+    Metrics->new->observe("imgsrv_prolog_seconds", time() - $start);
 
     $$env{'psgix.context'} = $C;
 }


### PR DESCRIPTION
NOTE: basing this PR on vanilla DEV-1076

Can be tested under the `babel` repo with the mdp-lib and imgsrv `singleton_variant` in branches swapped in, some reversions to the `babel` version of mdp-lib are required (Vendors, Utils for example).

I never got around to getting `catprocio` in place in the Dockerfile to test that.